### PR TITLE
Implement signup conflict handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,10 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+const users = [];
+
 app.use(express.static(path.join(__dirname)));
+app.use(express.json());
 
 app.get('/api/announcements', async (_req, res) => {
   try {
@@ -27,6 +30,25 @@ app.get('/api/announcements', async (_req, res) => {
     console.error(err);
     res.status(500).json({ error: 'Failed to fetch announcements' });
   }
+});
+
+app.post('/api/users', (req, res) => {
+  const { univid, name } = req.body;
+
+  if (!univid) {
+    return res.status(400).json({ error: 'University ID (univid) is required' });
+  }
+
+  const existing = users.find(u => u.univid === univid);
+  if (existing) {
+    return res
+      .status(409)
+      .json({ error: 'A user with this university ID already exists.' });
+  }
+
+  const user = { univid, name };
+  users.push(user);
+  res.status(201).json(user);
 });
 
 app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign Up</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+  <div class="container mt-5">
+    <h1>Sign Up</h1>
+    <form id="signup-form">
+      <div class="mb-3">
+        <label for="univid" class="form-label">University ID</label>
+        <input type="text" class="form-control" id="univid" name="univid" required>
+      </div>
+      <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" required>
+      </div>
+      <div id="error-msg" class="text-danger mb-3"></div>
+      <button type="submit" class="btn btn-primary">Sign Up</button>
+    </form>
+  </div>
+  <script src="signup.js"></script>
+</body>
+</html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('signup-form');
+  const errorMsg = document.getElementById('error-msg');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    errorMsg.textContent = '';
+
+    const payload = {
+      univid: form.univid.value,
+      name: form.name.value,
+    };
+
+    try {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (res.ok) {
+        window.location.href = '/';
+        return;
+      }
+
+      const data = await res.json();
+      if (res.status === 409) {
+        errorMsg.textContent = data.error;
+      } else {
+        errorMsg.textContent = data.error || 'Registration failed.';
+      }
+    } catch (err) {
+      errorMsg.textContent = 'An unexpected error occurred.';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add JSON body parsing and user storage to `server.js`
- implement `/api/users` POST endpoint with duplicate check
- create `signup.js` to handle signup flow and show server errors
- add simple `signup.html` for testing signup functionality

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687bcf4a44e4832e8e4f89e3709c95ab